### PR TITLE
image storing fails with cloud storage exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>
-    <googleCloudProjectId>summer22-sps-24</googleCloudProjectId>
+    <googleCloudProjectId>jhong-sps-summer22</googleCloudProjectId>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/google/sps/servlets/ListPostServlet.java
+++ b/src/main/java/com/google/sps/servlets/ListPostServlet.java
@@ -55,7 +55,7 @@ public class ListPostServlet extends HttpServlet {
             long tp = entity.getLong("timePosted");
             ZonedDateTime z = ZonedDateTime.ofInstant(Instant.ofEpochMilli(tp), ZoneId.systemDefault());
             ZonedDateTime timePosted = z.withZoneSameInstant(ZoneId.of("UTC"));
-            String photoURL = ""; //entity.getString("photoURL");
+            String photoURL = entity.getString("photoURL");
     
             Post post = new Post(id, petName, location, animalType, breed, dob, gender, vaccination, sickness, email, phone, timePosted, photoURL);
             posts.add(post);

--- a/src/main/java/com/google/sps/servlets/NewPostServlet.java
+++ b/src/main/java/com/google/sps/servlets/NewPostServlet.java
@@ -42,12 +42,12 @@ public class NewPostServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
         // Get the img file chosen by the user
-        // Part image = request.getPart("image");
-        // String imgFileName = image.getSubmittedFileName(); 
-        // InputStream imgInputStream = image.getInputStream();
+        Part image = request.getPart("image");
+        String imgFileName = image.getSubmittedFileName(); 
+        InputStream imgInputStream = image.getInputStream();
 
         // // Upload the file to cloud storage
-        // String imageURL = cloudStorageUpload(imgFileName, imgInputStream);
+        String imageURL = cloudStorageUpload(imgFileName, imgInputStream);
 
         // Get all options from Status and Gender enums as sets
         Set<String> genderSet = EnumUtils.getEnumMap(Gender.class).keySet(); // set of options in Gender enum
@@ -98,7 +98,7 @@ public class NewPostServlet extends HttpServlet {
                 .set("phone", phone)
                 .set("timePosted", timePosted)
                 //.set("status", status)
-                //.set("photoURL", imageURL)
+                .set("photoURL", imageURL)
                 .build();
         datastore.put(postEntity);
 
@@ -111,8 +111,8 @@ public class NewPostServlet extends HttpServlet {
     */
     private static String cloudStorageUpload(String fileName, InputStream fileInputStream) {
         //should edit once project id actually decided
-        String projectId = "summer22-sps-24";
-        String bucketName = "summer22-sps-24.appspot.com";
+        String projectId = "jhong-sps-summer22";
+        String bucketName = "jhong-sps-summer22.appspot.com";
 
         Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
 

--- a/src/main/webapp/newPost.html
+++ b/src/main/webapp/newPost.html
@@ -30,9 +30,9 @@
   <input type="email" id="emails" name="email" multiple> <br><br>
   <label for="phone">Phone number:</label>
   <input type="tel" id="phone" name="phone" placeholder="+001-123-456-7890" pattern="+[0-9]{3}-[0-9]{3}-[0-9]{3}-[0-9]{4}" required><br><br>
-  <!-- <label for="images">Choose images to upload (Must be *.jpg or *.jpeg or *.png)</label> -->
-  <!-- <input type="file" id="images" name="image" multiple
-          accept=".jpg, .jpeg, .png"><br><br> -->
+  <label for="images">Choose images to upload (Must be *.jpg or *.jpeg or *.png)</label> -->
+  <input type="file" id="images" name="image" multiple
+          accept=".jpg, .jpeg, .png"><br><br> 
   <input type="submit"> 
 </form>
 

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -36,6 +36,7 @@ function loadPosts() {
     fetch('/load-post').then(response => response.json()).then((posts) => {
     const postListElement = document.getElementById('post-container');
     posts.forEach((post) => {
+        console.log(post);
         postListElement.appendChild(createPostElement(post));
       })
     });


### PR DESCRIPTION
I've been having a bit of trouble with storing images to cloud (error starting at NewPostServlet.java:123). It's a little weird that I get slightly different cloud storage exceptions (Seemingly based on the type of the image file).

I've tried deploying to both the team and personal websites. In both cases I seem to have the same error. 
I looked through [this stack overflow post](https://stackoverflow.com/questions/51410633/service-account-does-not-have-storage-objects-get-access-for-google-cloud-storag) but couldn't quite figure out what exactly I should do to solve this. 

(See attached files for full error messages. One case is when I uploaded the jpeg file and the other is the jpg file case. In case they'd be needed, I'm also attaching the original files I used to upload for testing.) 

[error_(jpeg).pdf](https://github.com/estefanytorres/virtual-animal-shelter/files/9085800/error_.jpeg.pdf)
[error_(jpg).pdf](https://github.com/estefanytorres/virtual-animal-shelter/files/9085803/error_.jpg.pdf)

![PlasticZestyAnura-mobile](https://user-images.githubusercontent.com/98107325/178309909-0bd05b07-7e85-424f-ac97-358b6788de98.jpg)
![dusk](https://user-images.githubusercontent.com/98107325/178309986-38714f4c-860d-46ff-a863-54d04da69cd1.jpeg)

